### PR TITLE
feat(validation): Orders request validation + 400 ProblemDetail guardrail

### DIFF
--- a/src/main/java/com/waalterGar/projects/ecommerce/Dto/createOrderDto.java
+++ b/src/main/java/com/waalterGar/projects/ecommerce/Dto/createOrderDto.java
@@ -1,6 +1,9 @@
 package com.waalterGar.projects.ecommerce.Dto;
 
 import com.waalterGar.projects.ecommerce.utils.Currency;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -12,7 +15,12 @@ import java.util.List;
 @Setter
 @NoArgsConstructor
 public class createOrderDto {
+    @NotBlank(message = "customerExternalId is required")
     private String customerExternalId;
+
+    @NotNull(message = "currency is required")
     private Currency currency;
+
+    @NotEmpty(message = "items must not be empty")
     private List<createOrderItemDto> items;
 }

--- a/src/main/java/com/waalterGar/projects/ecommerce/Dto/createOrderItemDto.java
+++ b/src/main/java/com/waalterGar/projects/ecommerce/Dto/createOrderItemDto.java
@@ -1,6 +1,8 @@
 package com.waalterGar.projects.ecommerce.Dto;
 
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -10,6 +12,9 @@ import lombok.ToString;
 @Setter
 @NoArgsConstructor
 public class createOrderItemDto {
+    @NotBlank(message = "productSku is required")
     private String productSku;
+
+    @Positive(message = "quantity must be > 0")
     private Integer quantity;
 }

--- a/src/main/java/com/waalterGar/projects/ecommerce/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/waalterGar/projects/ecommerce/api/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.waalterGar.projects.ecommerce.api;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.UnexpectedTypeException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -57,6 +58,17 @@ public class GlobalExceptionHandler {
         );
         pd.setProperty("errors", parameterErrors(ex));
         return pd;
+    }
+
+    @ExceptionHandler(UnexpectedTypeException.class)
+    public ProblemDetail handleUnexpectedType(UnexpectedTypeException ex, HttpServletRequest req) {
+         return pd(
+                HttpStatus.BAD_REQUEST,
+                "Invalid Constraint Configuration",
+                "A server configuration error occurred.",
+                TYPE_VALIDATION,
+                req
+        );
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/waalterGar/projects/ecommerce/controller/OrderController.java
+++ b/src/main/java/com/waalterGar/projects/ecommerce/controller/OrderController.java
@@ -3,6 +3,7 @@ package com.waalterGar.projects.ecommerce.controller;
 import com.waalterGar.projects.ecommerce.Dto.OrderDto;
 import com.waalterGar.projects.ecommerce.Dto.createOrderDto;
 import com.waalterGar.projects.ecommerce.service.OrderService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,7 +17,7 @@ public class OrderController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public ResponseEntity<OrderDto> createOrder(@RequestBody createOrderDto orderDto){
+    public ResponseEntity<OrderDto> createOrder(@Valid @RequestBody createOrderDto orderDto){
         OrderDto createdOrder = orderService.createOrder(orderDto);
         return new ResponseEntity<>(createdOrder, HttpStatus.CREATED);
     }


### PR DESCRIPTION
## Summary
Lock down the Orders request contract with Bean Validation and ensure predictable RFC 7807 errors. Add a guardrail that maps UnexpectedTypeException to 400 (validation type), enable the previously disabled POST-invalid test, and update the docs.

## Changes
- Controller
  - Add @Valid to POST /api/orders.
- DTOs
  - createOrderDto: @NotBlank customerExternalId, @NotEmpty items (cascade @Valid).
  - createOrderItemDto: @NotBlank productSku, @Positive quantity.
  - currency: @NotNull (enum) or deferred per current configuration.
- GlobalExceptionHandler
  - Map UnexpectedTypeException → 400 (type: urn:problem:validation) to avoid 500 on misconfigured constraints.
- Tests (web slice, @WebMvcTest)
  - Re-enable: POST /api/orders invalid payload → 400 problem+json (service not called).
  - Add: service-thrown UnexpectedTypeException → 400 problem+json (guardrail).
  - Keep: GET 200 / 404 / 400 tests for consistency.
- README
  - Add “feat/validation” note.
  - Document Orders validation rules and a 400 validation ProblemDetail example.

## How to test
- Slice only (no DB):
  `./mvnw -Dtest=*ControllerTest test`
- Full suite (DB required):
  `docker-compose up -d && ./mvnw test`

## Next
- Consider property-driven base path (`/api`) and controller method/param rename for consistency.
- Begin business rules phase (e.g., stock checks, totals) with targeted unit/controller tests.