### PR TITLE
chore(api): move API under server.servlet.context-path=/api; drop hardcoded /api in controllers and tests.

### DIFF
--- a/src/main/java/com/waalterGar/projects/ecommerce/controller/CustomerController.java
+++ b/src/main/java/com/waalterGar/projects/ecommerce/controller/CustomerController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RequiredArgsConstructor
-@RequestMapping("/api/customers")
+@RequestMapping("/customers")
 @RestController
 public class CustomerController {
     private final CustomerService customerService;

--- a/src/main/java/com/waalterGar/projects/ecommerce/controller/OrderController.java
+++ b/src/main/java/com/waalterGar/projects/ecommerce/controller/OrderController.java
@@ -10,7 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
-@RequestMapping("/api/orders")
+@RequestMapping("/orders")
 @RestController
 public class OrderController {
     private final OrderService orderService;

--- a/src/main/java/com/waalterGar/projects/ecommerce/controller/ProductController.java
+++ b/src/main/java/com/waalterGar/projects/ecommerce/controller/ProductController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RequiredArgsConstructor
-@RequestMapping("/api/products")
+@RequestMapping("/products")
 @RestController
 public class ProductController {
     private final ProductService productService;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,4 @@ spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 spring.jpa.open-in-view=false
 server.port=8080
+server.servlet.context-path=/api

--- a/src/test/java/com/waalterGar/projects/ecommerce/controller/OrderControllerTest.java
+++ b/src/test/java/com/waalterGar/projects/ecommerce/controller/OrderControllerTest.java
@@ -26,7 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Import(GlobalExceptionHandler.class)
 @AutoConfigureMockMvc(addFilters = false)
 class OrderControllerTest {
-    private static final String BASE_URL = "/api/orders";
+    private static final String BASE_URL = "/orders";
     private static final String UNKNOWN_ORDER_ID = "ord-does-not-exist";
     private static final String ORDER_ID = "ord-123";
     private static final String UNKNOWN_URL = BASE_URL + "/" + UNKNOWN_ORDER_ID;


### PR DESCRIPTION
## Summary
Make the API base path consistent via `server.servlet.context-path=/api` and remove hardcoded `/api` segments from controller mappings.

## Changes
- Set `server.servlet.context-path=/api`.
- Update Order/Product/Customer controllers to use relative mappings (`/orders`, `/products`, `/customers`).
- Update tests.
## Notes
- Actuator/error endpoints also live under `/api` now.