### PR TITLE
chore(api): polish global error handling (malformed JSON, unknown route) + web-slice tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,14 @@ Si la validación falla, se devuelve **400** con `application/problem+json` y un
 La API estandariza los errores usando **RFC 7807 – `application/problem+json`**.  
 Todas las respuestas de error incluyen: `type`, `title`, `status`, `detail`, `path`, `timestamp`.
 
-Ejemplos:
+- **400** `urn:problem:malformed-json` — cuerpo JSON mal formado.
 
-**404 Not Found** (recurso no encontrado, p.ej. `NoSuchElementException`)
+
+- **404** `urn:problem:no-resource` — ruta no mapeada/recurso no encontrado.
+
+
+
+- **404 Not Found** (recurso no encontrado, p.ej. `NoSuchElementException`)
 ```json
 {
   "type": "urn:problem:not-found",
@@ -146,7 +151,7 @@ Ejemplos:
 }
 ```
 
-**400 Bad Request** (entrada inválida, p.ej. `IllegalArgumentException`)
+- **400 Bad Request** (entrada inválida, p.ej. `IllegalArgumentException`)
 ```json
 {
   "type": "urn:problem:invalid-request",
@@ -158,7 +163,7 @@ Ejemplos:
 }
 ```
 
-**400 Bad Request** (errores de validación en el cuerpo de la petición)
+- **400 Bad Request** (errores de validación en el cuerpo de la petición)
 ```json
 {
   "type": "urn:problem:validation",

--- a/src/main/java/com/waalterGar/projects/ecommerce/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/waalterGar/projects/ecommerce/api/GlobalExceptionHandler.java
@@ -78,7 +78,6 @@ public class GlobalExceptionHandler {
         );
     }
 
-
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ProblemDetail handleMalformedJson(HttpMessageNotReadableException ex, HttpServletRequest req) {
         String detail = ex.getMostSpecificCause() != null


### PR DESCRIPTION
## Summary
Extend global RFC7807 error handling to cover common 400/404 scenarios and add controller-slice tests.

## Changes
- GlobalExceptionHandler:
  - 400: HttpMessageNotReadableException → type: urn:problem:malformed-json
  - 400: MethodArgumentTypeMismatchException → type: urn:problem:type-mismatch
  - 400: MissingServletRequestParameterException → type: urn:problem:missing-param
  - 404: NoResourceFoundException → type: urn:problem:no-resource
- Tests:
  - POST /api/orders with malformed JSON → 400 problem+json
  - GET unknown route → 404 problem+json
- Docs: minor README note about new problem types
