### PR TITLE
test(web): complete Orders web slice (POST 201) + 415/406 ProblemDetail; docs update

### DIFF
--- a/src/main/java/com/waalterGar/projects/ecommerce/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/waalterGar/projects/ecommerce/api/GlobalExceptionHandler.java
@@ -11,6 +11,8 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
+import org.springframework.web.HttpMediaTypeNotAcceptableException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
 
 import java.net.URI;
 import java.time.Instant;
@@ -30,6 +32,9 @@ public class GlobalExceptionHandler {
     private static final URI TYPE_MISSING_PARAM   = URI.create("urn:problem:missing-param");
     private static final URI TYPE_NO_RESOURCE     = URI.create("urn:problem:no-resource");
     private static final URI TYPE_UNEXPECTED      = URI.create("urn:problem:unexpected");
+    private static final URI TYPE_UNSUPPORTED_MEDIA = URI.create("urn:problem:unsupported-media-type");
+    private static final URI TYPE_NOT_ACCEPTABLE    = URI.create("urn:problem:not-acceptable");
+
 
     @ExceptionHandler(NoSuchElementException.class)
     public ProblemDetail handleNotFound(NoSuchElementException ex, HttpServletRequest req) {
@@ -103,6 +108,16 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(NoResourceFoundException.class)
     public ProblemDetail handleNoResource(NoResourceFoundException ex, HttpServletRequest req) {
         return pd(HttpStatus.NOT_FOUND, "No Resource Found", ex.getMessage(), TYPE_NO_RESOURCE, req);
+    }
+
+    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+    public ProblemDetail handleUnsupportedMediaType(HttpMediaTypeNotSupportedException ex, HttpServletRequest req) {
+        return pd(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "Unsupported Media Type", ex.getMessage(), TYPE_UNSUPPORTED_MEDIA, req);
+    }
+
+    @ExceptionHandler(HttpMediaTypeNotAcceptableException.class)
+    public ProblemDetail handleNotAcceptable(HttpMediaTypeNotAcceptableException ex, HttpServletRequest req) {
+        return pd(HttpStatus.NOT_ACCEPTABLE, "Not Acceptable", ex.getMessage(), TYPE_NOT_ACCEPTABLE, req);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/test/java/com/waalterGar/projects/ecommerce/controller/OrderControllerTest.java
+++ b/src/test/java/com/waalterGar/projects/ecommerce/controller/OrderControllerTest.java
@@ -164,4 +164,32 @@ class OrderControllerTest {
 
         verifyNoInteractions(orderService);
     }
+
+    @Test
+    void createOrder_valid_returns201_withBody() throws Exception {
+        String payload = """
+      {
+        "customerExternalId": "cust-123",
+        "currency": "EUR",
+        "items": [ { "productSku": "SKU-1", "quantity": 2 } ]
+      }""";
+
+        OrderDto returned = new OrderDto();
+        returned.setExternalId("ord-xyz");
+
+        when(orderService.createOrder(any())).thenReturn(returned);
+
+        mvc.perform(post(BASE_URL) // BASE_URL = "/api/orders"
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isCreated())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.externalId").value("ord-xyz"))
+                .andExpect(handler().handlerType(OrderController.class))
+                .andExpect(handler().methodName("createOrder"));
+
+        verify(orderService).createOrder(any());
+        verifyNoMoreInteractions(orderService);
+    }
 }


### PR DESCRIPTION
## Summary
Finalize the Orders web-layer contract. Adds a happy-path POST (201), standardizes media negotiation errors (415/406) via RFC7807 ProblemDetail, and updates the README.

## Changes
- Tests (web slice, @WebMvcTest):
  - POST /api/orders valid → 201 with JSON body (externalId).
  - 415 Unsupported Media Type when Content-Type is not application/json.
  - 406 Not Acceptable when the Accept header cannot be satisfied.
  - Keep existing coverage: GET 200/404/400, malformed JSON 400, unknown route 404.
- GlobalExceptionHandler:
  - Map HttpMediaTypeNotSupportedException → 415 (type: urn:problem:unsupported-media-type).
  - Map HttpMediaTypeNotAcceptableException → 406 (type: urn:problem:not-acceptable).
- README:
  - Note context path (/api).
  - Add POST 201 example for Orders.
  - Add ProblemDetail examples for 415 and 406.
  - Update OrderController test coverage bullets.