### PR TITLE
test(jpa): complete Order repository ITs (MySQL Testcontainers) + docs(readme) update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # Ecommerce API 🛒
 
+> **Novedades de `test/jpa-with-testcontainers`**: tests de persistencia con **MySQL Testcontainers**; ITs del repositorio de Orders (**distinct roots**, **orphanRemoval**, **cascade persist**); builders de test ajustados (listas **mutables** + back-refs vía `Order.addItem/removeItem`); smoke `@SpringBootTest` configurado para usar el contenedor.
+>
 > **Novedades de `feat/validation`**: validación mínima en DTOs de Orders (`@Valid`, `@NotBlank`, `@NotEmpty`, `@Positive`, `@NotNull`) y habilitado el test **POST inválido → 400**; además, se mapea `UnexpectedTypeException` a **400** como guardarraíl de validación.
+
 ---
+
 ## 📋 Descripción
 
 API REST de un **ecommerce ficticio**, desarrollada con **Spring Boot**, conectada a **MySQL** mediante **Spring Data JPA**.  
@@ -17,12 +21,13 @@ Este proyecto sirve como base para demostrar mis habilidades en backend, aplican
 - **MySQL 8** (contenedor Docker)
 - **Docker Compose**
 - **Maven**
+- **Testcontainers** (tests de persistencia con MySQL real en contenedor)
 
 ---
 
 ## ⚙️ Configuración y ejecución
 
-> **server.servlet.context-path=/api** → todos los endpoints viven bajo `/api`.
+> `server.servlet.context-path=/api` → todos los endpoints viven bajo `/api`.
 
 ### 1. Variables de entorno
 Crea un archivo `.env` en la raíz del proyecto con las siguientes variables (⚠️ el archivo está en `.gitignore` y no se versiona):
@@ -34,13 +39,12 @@ MYSQL_PASSWORD=ecommerce_pass
 MYSQL_ROOT_PASSWORD=rootpass
 ```
 
-### 2. Levantar la base de datos con Docker
+### 2. Levantar la base de datos para ejecutar la **aplicación**
 En la raíz del proyecto:
 ```bash
 docker-compose up -d
 ```
 Esto levantará:
-
 - MySQL en el puerto 3306
 - (Opcional) phpMyAdmin en http://localhost:8081
 
@@ -48,6 +52,8 @@ Esto levantará:
 ```bash
 ./mvnw spring-boot:run
 ```
+
+> 🔎 **Tests**: no necesitas `docker-compose` para ejecutar los tests de persistencia; **Testcontainers** arranca un MySQL efímero automáticamente.
 
 ---
 
@@ -98,7 +104,7 @@ Esto levantará:
 ### 🧾 Orders
 > Requisitos: el `customerExternalId` y los `productSku` deben existir previamente.
 
-- **POST** `/api/orders` → Crear un pedido
+- **POST** `/api/orders` → Crear un pedido  
   **Body ejemplo:**
   ```json
   {
@@ -110,21 +116,17 @@ Esto levantará:
   }
   ```
   **Respuesta (201 Created)**
-```json
-  {
-    "externalId": "ord-xyz"
-  }
-```
-
+  ```json
+  { "externalId": "ord-xyz" }
+  ```
 
 - **GET** `/api/orders/{externalId}` → Obtener un pedido por su `externalId`  
-  **Nota**: actualmente, si no existe lanza `NoSuchElementException("Order not found")`, que se mapea a **HTTP 404** mediante el handler global.
+  **Nota**: si no existe, lanza `NoSuchElementException("Order not found")`, que se mapea a **HTTP 404** mediante el handler global.
 
 - **GET** `/api/orders` → Listar todos los pedidos (con items y customer precargados)
 
-
 **Validación de entrada (createOrder)**  
-Se aplica validación de Bean Validation en el payload:
+Se aplica Bean Validation en el payload:
 - `customerExternalId`: **@NotBlank**
 - `items`: **@NotEmpty**
   - cada item:
@@ -142,135 +144,109 @@ La API estandariza los errores usando **RFC 7807 – `application/problem+json`*
 Todas las respuestas de error incluyen: `type`, `title`, `status`, `detail`, `path`, `timestamp`.
 
 - **400** `urn:problem:malformed-json` — cuerpo JSON mal formado.
-
-
 - **404** `urn:problem:no-resource` — ruta no mapeada/recurso no encontrado.
-
-
-
-- **404 Not Found** (recurso no encontrado, p.ej. `NoSuchElementException`)
-```json
-{
-  "type": "urn:problem:not-found",
-  "title": "Resource Not Found",
-  "status": 404,
-  "detail": "Order not found",
-  "path": "/api/orders/ord-does-not-exist",
-  "timestamp": "2025-10-01T18:00:00Z"
-}
-```
-
-- **400 Bad Request** (entrada inválida, p.ej. `IllegalArgumentException`)
-```json
-{
-  "type": "urn:problem:invalid-request",
-  "title": "Invalid Request",
-  "status": 400,
-  "detail": "Invalid externalId",
-  "path": "/api/orders/bad",
-  "timestamp": "2025-10-01T18:00:00Z"
-}
-```
-
-- **400 Bad Request** (errores de validación en el cuerpo de la petición)
-```json
-{
-  "type": "urn:problem:validation",
-  "title": "Validation Failed",
-  "status": 400,
-  "detail": "One or more fields are invalid.",
-  "path": "/api/orders",
-  "timestamp": "2025-10-02T18:00:00Z",
-  "errors": {
-    "customerExternalId": "customerExternalId is required",
-    "items": "items must not be empty"
+- **404** `urn:problem:not-found` — recurso inexistente (p. ej. `NoSuchElementException`).
+  ```json
+  {
+    "type": "urn:problem:not-found",
+    "title": "Resource Not Found",
+    "status": 404,
+    "detail": "Order not found",
+    "path": "/api/orders/ord-does-not-exist",
+    "timestamp": "2025-10-01T18:00:00Z"
   }
-}
-```
+  ```
+- **400** `urn:problem:invalid-request` — petición inválida (p. ej. `IllegalArgumentException`).
+  ```json
+  {
+    "type": "urn:problem:invalid-request",
+    "title": "Invalid Request",
+    "status": 400,
+    "detail": "Invalid externalId",
+    "path": "/api/orders/bad",
+    "timestamp": "2025-10-01T18:00:00Z"
+  }
+  ```
+- **400** `urn:problem:validation` — errores de validación en el cuerpo.
+  ```json
+  {
+    "type": "urn:problem:validation",
+    "title": "Validation Failed",
+    "status": 400,
+    "detail": "One or more fields are invalid.",
+    "path": "/api/orders",
+    "timestamp": "2025-10-02T18:00:00Z",
+    "errors": {
+      "customerExternalId": "customerExternalId is required",
+      "items": "items must not be empty"
+    }
+  }
+  ```
+- **415** `urn:problem:unsupported-media-type` — `Content-Type` no soportado.
+- **406** `urn:problem:not-acceptable` — `Accept` no negociable.
 
-**415 Unsupported Media Type** (cabecera `Content-Type` no soportada)
-```json
-{
-  "type": "urn:problem:unsupported-media-type",
-  "title": "Unsupported Media Type",
-  "status": 415,
-  "detail": "Content type 'text/plain' not supported",
-  "path": "/api/orders",
-  "timestamp": "2025-10-02T18:00:00Z"
-}
-```
-
-**406 Not Acceptable** (cabecera `Accept` no negociable)
-```json
-{
-  "type": "urn:problem:not-acceptable",
-  "title": "Not Acceptable",
-  "status": 406,
-  "detail": "Could not find acceptable representation",
-  "path": "/api/orders",
-  "timestamp": "2025-10-02T18:00:00Z"
-}
-```
-
-> **Nota**: si se produce una configuración errónea de una constraint (p. ej., usar `@NotBlank` en un enum), el sistema devuelve **400** con `type: urn:problem:validation` gracias al handler para `UnexpectedTypeException`.
+> **Nota**: si se configura mal una constraint (p. ej., `@NotBlank` en un enum), el sistema devuelve **400** con `type: urn:problem:validation` gracias al handler de `UnexpectedTypeException`.
 
 ---
 
 ## 🧪 Tests
 
-El proyecto incluye tests unitarios con **JUnit 5** y **Mockito**.
-> Nota: hay un `@SpringBootTest` de arranque de contexto (`EcommerceApiApplicationTests`) que **requiere la BD levantada**.
-
-Cobertura actual:
+El proyecto incluye tests unitarios (JUnit 5 + Mockito), slice web y **tests de integración JPA con Testcontainers**.
 
 - **`ProductServiceImpl`**
   - `createProduct`: guarda y mapea correctamente.
   - `getProductBySku`: recupera por SKU (existe / no existe).
   - `getAllProducts`: lista vacía si no hay productos.
 
-
 - **`CustomerServiceImpl`**
   - `createCustomer`: guarda y mapea correctamente.
   - `getCustomerByExternalId`: recupera por `externalId` (existe / no existe).
   - `getAllCustomers`: lista vacía.
 
-
 - **`OrderServiceImpl`** (Mockito, sin contexto Spring)
   - `getOrderByExternalId`: encontrado → DTO con items y totales.
-  - `getOrderByExternalId`: no encontrado → lanza `NoSuchElementException("Order not found")`.
-  - `getAllOrders`: lista vacía.
-  - `getAllOrders`: con datos → valida `externalId` y `totalAmount`.
+  - `getOrderByExternalId`: no encontrado → `NoSuchElementException`.
+  - `getAllOrders`: lista vacía / con datos (valida `externalId` y `totalAmount`).
   - `createOrder`: happy-path → devuelve DTO con items y `totalAmount`.
   - `createOrder`: customer no existe → lanza y **no** guarda.
   - `createOrder`: product no existe → lanza y **no** guarda.
 
-
 - **`OrderController`** (slice web, `@WebMvcTest` + handler global)
   - `GET /api/orders/{id}` → **200** y JSON de pedido.
-  - `GET /api/orders/{id}` (no existe) → **404** `application/problem+json`.
-  - `GET /api/orders/{id}` (input inválido) → **400** `application/problem+json`.
-  - `POST /api/orders` **válido** → **201** y JSON con `externalId`.
-  - `POST /api/orders` **mal JSON** → **400** `application/problem+json`.
-  - `POST /api/orders` **Content-Type no soportado** → **415** `application/problem+json`.
-  - `POST /api/orders` **Accept no negociable** → **406** `application/problem+json`.
-  - Ruta desconocida → **404** `application/problem+json`.
+  - `GET /api/orders/{id}` (no existe) → **404** problem.
+  - `GET /api/orders/{id}` (input inválido) → **400** problem.
+  - `POST /api/orders` **válido** → **201** JSON con `externalId`.
+  - `POST /api/orders` **mal JSON** → **400** problem.
+  - `POST /api/orders` **Content-Type no soportado** → **415** problem.
+  - `POST /api/orders` **Accept no negociable** → **406** problem.
+  - Ruta desconocida → **404** problem.
 
+- **`OrderRepositoryIT`** (JPA + **MySQL Testcontainers**)
+  - **Distinct roots**: `findAllWithItemsAndCustomer` devuelve órdenes **sin duplicar** y con conteo correcto de items.
+  - **Orphan removal**: eliminar un item del agregado lo borra en DB (`orphanRemoval = true`).
+  - **Cascade persist**: guardar sólo el `Order` persiste también sus `OrderItem`s; se validan IDs y back-refs.
 
 ### Ejecutar tests
 - **Sólo el slice web (no requiere BD):**
   ```bash
   ./mvnw -Dtest=*ControllerTest test
   ```
-- **Suite completa** (requiere MySQL con Docker Compose):
+- **Sólo los IT de repositorio (arranca Testcontainers automáticamente):**
   ```bash
-  docker-compose up -d
+  ./mvnw -Dtest='*OrderRepositoryIT' test
+  ```
+- **Suite completa**:
+  ```bash
   ./mvnw test
   ```
+
+> Testcontainers descarga imágenes la primera vez; posteriores ejecuciones son más rápidas.
 
 ---
 
 ## 📈 Próximos pasos
-- Añadir más endpoints (pedidos, categorías).
-- Implementar seguridad con Spring Security y JWT.
-- Implementar manejo avanzado de errores y validaciones.
-- Ampliar la cobertura de tests.
+- Reglas de negocio (v1): stock mínimo, decremento de stock, totales “autoritativos”, estado inicial `NEW`, transaccionalidad, 422 (insufficient stock) con ProblemDetail.
+- Añadir más endpoints (categorías, etc.).
+- Seguridad con Spring Security + JWT.
+- Validaciones adicionales y manejo avanzado de errores.
+- Ampliar la cobertura de tests end-to-end.

--- a/pom.xml
+++ b/pom.xml
@@ -1,35 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>3.5.6</version>
-		<relativePath/> <!-- lookup parent from repository -->
+		<relativePath/>
 	</parent>
+
 	<groupId>com.waalterGar.projects</groupId>
 	<artifactId>ecommerce</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<name>Ecommerce API</name>
 	<description>Backend REST API for a simple ecommerce demo built with Spring Boot, JPA, and MySQL</description>
-	<url/>
-	<licenses>
-		<license/>
-	</licenses>
-	<developers>
-		<developer/>
-	</developers>
-	<scm>
-		<connection/>
-		<developerConnection/>
-		<tag/>
-		<url/>
-	</scm>
+
 	<properties>
 		<java.version>21</java.version>
 	</properties>
+
+	<!-- Manage Testcontainers versions via BOM -->
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.testcontainers</groupId>
+				<artifactId>testcontainers-bom</artifactId>
+				<version>1.20.2</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
+		<!-- Spring starters -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
@@ -43,30 +49,42 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 
+		<!-- Runtime DB driver -->
+		<dependency>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+
+		<!-- Devtools (optional) -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>
 			<scope>runtime</scope>
 			<optional>true</optional>
 		</dependency>
-		<dependency>
-			<groupId>com.mysql</groupId>
-			<artifactId>mysql-connector-j</artifactId>
-			<scope>runtime</scope>
-		</dependency>
+
+		<!-- Lombok (optional) -->
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
 		</dependency>
+
+		<!-- Test -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>mysql</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -85,6 +103,7 @@
 					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
+
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
@@ -99,5 +118,4 @@
 			</plugin>
 		</plugins>
 	</build>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,11 @@
 		<!-- Test -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-testcontainers</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/src/test/java/com/waalterGar/projects/ecommerce/EcommerceApiApplicationTests.java
+++ b/src/test/java/com/waalterGar/projects/ecommerce/EcommerceApiApplicationTests.java
@@ -1,12 +1,25 @@
 package com.waalterGar.projects.ecommerce;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 @SpringBootTest
+@Testcontainers
+@AutoConfigureTestDatabase(replace = Replace.NONE) // use the container DataSource, not an in-memory one
 class EcommerceApiApplicationTests {
+
+	@Container
+	@ServiceConnection // Boot 3.1+ will auto-map spring.datasource.* from this container
+	static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0.37");
 
 	@Test
 	void contextLoads() {
+		// boots the whole Spring context against the containerized MySQL
 	}
 }

--- a/src/test/java/com/waalterGar/projects/ecommerce/repository/OrderRepositoryIT.java
+++ b/src/test/java/com/waalterGar/projects/ecommerce/repository/OrderRepositoryIT.java
@@ -1,0 +1,73 @@
+package com.waalterGar.projects.ecommerce.repository;
+
+import com.waalterGar.projects.ecommerce.entity.Customer;
+import com.waalterGar.projects.ecommerce.entity.Order;
+import com.waalterGar.projects.ecommerce.testsupport.builders.CustomerBuilder;
+import com.waalterGar.projects.ecommerce.testsupport.builders.OrderBuilder;
+import com.waalterGar.projects.ecommerce.testsupport.builders.OrderItemBuilder;
+import com.waalterGar.projects.ecommerce.utils.Currency;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Testcontainers
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class OrderRepositoryIT {
+
+    @Container
+    @ServiceConnection  // Boot wires spring.datasource.* from this container
+    static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0.37");
+    @Autowired OrderRepository orderRepository;
+    @Autowired CustomerRepository customerRepository;
+
+    private static final String CUSTOMER_EXT_ID = "cust-it-1";
+    private static final String ORDER_EXT_ID = "ord-it-1";
+
+    @Test
+    void findAllWithItemsAndCustomer_returnsOrders_withItemsAndCustomerLoaded() {
+        // Arrange
+        Customer customer = new CustomerBuilder().withExternalId(CUSTOMER_EXT_ID).build();
+        Customer savedCustomer = customerRepository.save(customer);
+
+        Order order = new OrderBuilder()
+                .withExternalId(ORDER_EXT_ID)
+                .withCustomer(savedCustomer)
+                .addItem(new OrderItemBuilder()
+                        .withSku("MUG-LOGO-001")
+                        .withName("Logo Mug")
+                        .withQuantity(2)
+                        .withUnitPrice(new BigDecimal("19.99"))
+                        .withCurrency(Currency.EUR)
+                        .build())
+                .build();
+        //Set the bi-directional relationship
+        order.getItems().forEach(item -> item.setOrder(order));
+
+        orderRepository.save(order);
+
+        // Act
+        List<Order> result = orderRepository.findAllWithItemsAndCustomer();
+
+        // Assert
+        assertThat(result).hasSize(1);
+        Order persistedOrder = result.get(0);
+        assertThat(persistedOrder.getExternalId()).isEqualTo(ORDER_EXT_ID);
+        // customer eagerly available
+        assertThat(persistedOrder.getCustomer().getExternalId()).isEqualTo(CUSTOMER_EXT_ID);
+        // items eagerly available
+        assertThat(persistedOrder.getItems()).hasSize(1);
+        assertThat(persistedOrder.getItems().get(0).getProductSku()).isEqualTo("MUG-LOGO-001");
+        assertThat(persistedOrder.getItems().get(0).getQuantity()).isEqualTo(2);
+    }
+}

--- a/src/test/java/com/waalterGar/projects/ecommerce/repository/OrderRepositoryIT.java
+++ b/src/test/java/com/waalterGar/projects/ecommerce/repository/OrderRepositoryIT.java
@@ -2,6 +2,7 @@ package com.waalterGar.projects.ecommerce.repository;
 
 import com.waalterGar.projects.ecommerce.entity.Customer;
 import com.waalterGar.projects.ecommerce.entity.Order;
+import com.waalterGar.projects.ecommerce.entity.OrderItem;
 import com.waalterGar.projects.ecommerce.testsupport.builders.CustomerBuilder;
 import com.waalterGar.projects.ecommerce.testsupport.builders.OrderBuilder;
 import com.waalterGar.projects.ecommerce.testsupport.builders.OrderItemBuilder;
@@ -11,10 +12,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.test.context.TestPropertySource;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+
 import java.math.BigDecimal;
 import java.util.List;
 
@@ -26,33 +27,31 @@ import static org.assertj.core.api.Assertions.assertThat;
 class OrderRepositoryIT {
 
     @Container
-    @ServiceConnection  // Boot wires spring.datasource.* from this container
+    @ServiceConnection
     static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0.37");
+
     @Autowired OrderRepository orderRepository;
     @Autowired CustomerRepository customerRepository;
 
-    private static final String CUSTOMER_EXT_ID = "cust-it-1";
-    private static final String ORDER_EXT_ID = "ord-it-1";
+    private static final String CUSTOMER_EXT_ID    = "cust-it-1";
+    private static final String CUSTOMER_EXT_ID_A  = "cust-A";
+    private static final String ORDER_EXT_ID_1     = "ord-it-1";
+    private static final String ORDER_EXT_ID_2     = "ord-it-2";
+    private static final String SKU_MUG            = "MUG-LOGO-001";
+    private static final String NAME_MUG           = "Logo Mug";
+    private static final String SKU_TSHIRT         = "TSHIRT-LOGO-001";
+    private static final String NAME_TSHIRT        = "Logo T-Shirt";
+    private static final BigDecimal PRICE_MUG      = new BigDecimal("19.99");
+    private static final BigDecimal PRICE_TSHIRT   = new BigDecimal("9.99");
+    private static final int QTY_ONE               = 1;
+    private static final int QTY_TWO               = 2;
 
     @Test
     void findAllWithItemsAndCustomer_returnsOrders_withItemsAndCustomerLoaded() {
         // Arrange
-        Customer customer = new CustomerBuilder().withExternalId(CUSTOMER_EXT_ID).build();
-        Customer savedCustomer = customerRepository.save(customer);
-
-        Order order = new OrderBuilder()
-                .withExternalId(ORDER_EXT_ID)
-                .withCustomer(savedCustomer)
-                .addItem(new OrderItemBuilder()
-                        .withSku("MUG-LOGO-001")
-                        .withName("Logo Mug")
-                        .withQuantity(2)
-                        .withUnitPrice(new BigDecimal("19.99"))
-                        .withCurrency(Currency.EUR)
-                        .build())
-                .build();
-        //Set the bi-directional relationship
-        order.getItems().forEach(item -> item.setOrder(order));
+        Customer saved = savedCustomer(CUSTOMER_EXT_ID);
+        Order order = orderWith(saved, ORDER_EXT_ID_1,
+                item(SKU_MUG, NAME_MUG, QTY_TWO, PRICE_MUG));
 
         orderRepository.save(order);
 
@@ -61,13 +60,93 @@ class OrderRepositoryIT {
 
         // Assert
         assertThat(result).hasSize(1);
-        Order persistedOrder = result.get(0);
-        assertThat(persistedOrder.getExternalId()).isEqualTo(ORDER_EXT_ID);
-        // customer eagerly available
-        assertThat(persistedOrder.getCustomer().getExternalId()).isEqualTo(CUSTOMER_EXT_ID);
-        // items eagerly available
-        assertThat(persistedOrder.getItems()).hasSize(1);
-        assertThat(persistedOrder.getItems().get(0).getProductSku()).isEqualTo("MUG-LOGO-001");
-        assertThat(persistedOrder.getItems().get(0).getQuantity()).isEqualTo(2);
+
+        Order persisted = result.get(0);
+        assertThat(persisted.getExternalId()).isEqualTo(ORDER_EXT_ID_1);
+        assertThat(persisted.getCustomer().getExternalId()).isEqualTo(CUSTOMER_EXT_ID);
+        assertThat(persisted.getItems()).hasSize(1);
+        assertThat(persisted.getItems().get(0).getProductSku()).isEqualTo(SKU_MUG);
+        assertThat(persisted.getItems().get(0).getQuantity()).isEqualTo(QTY_TWO);
+    }
+
+    @Test
+    void findAllWithItemsAndCustomer_returnsDistinctOrders_withCorrectItemCounts() {
+        // Arrange
+        Customer c = savedCustomer(CUSTOMER_EXT_ID_A);
+
+        Order o1 = orderWith(c, ORDER_EXT_ID_1,
+                item(SKU_MUG, NAME_MUG, QTY_TWO, PRICE_MUG),
+                item(SKU_TSHIRT, NAME_TSHIRT, QTY_ONE, PRICE_TSHIRT));
+
+        Order o2 = orderWith(c, ORDER_EXT_ID_2,
+                item(SKU_MUG, NAME_MUG, QTY_ONE, PRICE_MUG));
+
+        orderRepository.save(o1);
+        orderRepository.save(o2);
+
+        // Act
+        List<Order> result = orderRepository.findAllWithItemsAndCustomer();
+
+        // Assert
+        assertThat(result).extracting(Order::getExternalId)
+                .containsExactlyInAnyOrder(ORDER_EXT_ID_1, ORDER_EXT_ID_2);
+
+        assertThat(getByExternalId(result, ORDER_EXT_ID_1).getItems()).hasSize(2);
+        assertThat(getByExternalId(result, ORDER_EXT_ID_2).getItems()).hasSize(1);
+    }
+
+    @Test
+    void removingItem_fromOrder_deletesOrphan_whenOrphanRemovalEnabled() {
+        // Arrange
+        Customer saved = savedCustomer(CUSTOMER_EXT_ID);
+        Order o1 = orderWith(saved, ORDER_EXT_ID_1,
+                item(SKU_MUG, NAME_MUG, QTY_TWO, PRICE_MUG),
+                item(SKU_TSHIRT, NAME_TSHIRT, QTY_ONE, PRICE_TSHIRT));
+
+        o1 = orderRepository.saveAndFlush(o1);
+
+        int initialSize = o1.getItems().size();
+        OrderItem toRemove = o1.getItems().get(0);
+        o1.removeItem(toRemove);
+        orderRepository.saveAndFlush(o1);
+
+        // Act
+        List<Order> result = orderRepository.findAllWithItemsAndCustomer();
+
+        // Assert
+        assertThat(getByExternalId(result, ORDER_EXT_ID_1).getItems()).hasSize(initialSize - 1);
+    }
+
+    private Customer savedCustomer(String externalId) {
+        return customerRepository.save(
+                new CustomerBuilder().withExternalId(externalId).build()
+        );
+    }
+
+    private OrderItem item(String sku, String name, int quantity, BigDecimal unitPrice) {
+        return new OrderItemBuilder()
+                .withSku(sku)
+                .withName(name)
+                .withQuantity(quantity)
+                .withUnitPrice(unitPrice)
+                .withCurrency(Currency.EUR)
+                .build();
+    }
+
+    private Order orderWith(Customer customer, String externalId, OrderItem... items) {
+        OrderBuilder ob = new OrderBuilder()
+                .withExternalId(externalId)
+                .withCustomer(customer);
+        for (OrderItem it : items) {
+            ob.addItem(it);
+        }
+        return ob.build();
+    }
+
+    private Order getByExternalId(List<Order> orders, String externalId) {
+        return orders.stream()
+                .filter(o -> externalId.equals(o.getExternalId()))
+                .findFirst()
+                .orElseThrow();
     }
 }

--- a/src/test/java/com/waalterGar/projects/ecommerce/testsupport/builders/CustomerBuilder.java
+++ b/src/test/java/com/waalterGar/projects/ecommerce/testsupport/builders/CustomerBuilder.java
@@ -1,20 +1,55 @@
 package com.waalterGar.projects.ecommerce.testsupport.builders;
 
 import com.waalterGar.projects.ecommerce.entity.Customer;
+import com.waalterGar.projects.ecommerce.utils.CountryCode;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 public class CustomerBuilder {
     private String externalId = UUID.randomUUID().toString();
     private boolean isActive = true;
+    private String firstName = "John";
+    private String lastName = "Doe";
+    private String email = "john.doe@example.com";
+    private String phoneNumber = "123456789";
+    private String address = "123 Main St";
+    private String city = "Madrid";
+    private String state = "Madrid";
+    private String zipCode = "28001";
+    private CountryCode countryCode = CountryCode.ES;
+    private LocalDateTime createdAt = LocalDateTime.now();
+    private LocalDateTime updatedAt = LocalDateTime.now();
 
     public CustomerBuilder withExternalId(String id) { this.externalId = id; return this; }
     public CustomerBuilder inactive() { this.isActive = false; return this; }
+    public CustomerBuilder withFirstName(String fn) { this.firstName = fn; return this; }
+    public CustomerBuilder withLastName(String ln) { this.lastName = ln; return this; }
+    public CustomerBuilder withEmail(String em) { this.email = em; return this; }
+    public CustomerBuilder withPhoneNumber(String pn) { this.phoneNumber = pn; return this; }
+    public CustomerBuilder withAddress(String addr) { this.address = addr; return this; }
+    public CustomerBuilder withCity(String city) { this.city = city; return this; }
+    public CustomerBuilder withState(String state) { this.state = state; return this; }
+    public CustomerBuilder withZipCode(String zip) { this.zipCode = zip; return this; }
+    public CustomerBuilder withCountryCode(CountryCode cc) { this.countryCode = cc; return this; }
+    public CustomerBuilder withCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; return this; }
+    public CustomerBuilder withUpdatedAt(LocalDateTime updatedAt) { this.updatedAt = updatedAt; return this; }
 
     public Customer build() {
         Customer c = new Customer();
         c.setExternalId(externalId);
         c.setIsActive(isActive);
+        c.setFirstName(firstName);
+        c.setLastName(lastName);
+        c.setEmail(email);
+        c.setPhoneNumber(phoneNumber);
+        c.setAddress(address);
+        c.setCity(city);
+        c.setState(state);
+        c.setZipCode(zipCode);
+        c.setCountryCode(countryCode);
+        c.setCreatedAt(createdAt);
+        c.setUpdatedAt(updatedAt);
         return c;
     }
 }

--- a/src/test/java/com/waalterGar/projects/ecommerce/testsupport/builders/OrderBuilder.java
+++ b/src/test/java/com/waalterGar/projects/ecommerce/testsupport/builders/OrderBuilder.java
@@ -29,8 +29,10 @@ public class OrderBuilder {
         o.setExternalId(externalId);
         o.setStatus(status);
         o.setCurrency(currency);
-        o.setCustomer(customer); // ensures no NPEs
-        o.setItems(List.copyOf(items));
+        o.setCustomer(customer);
+
+        for (OrderItem it : items) {o.addItem(it);}
+
         BigDecimal total = items.stream()
                 .map(OrderItem::getLineTotal)
                 .reduce(BigDecimal.ZERO, BigDecimal::add);

--- a/src/test/java/com/waalterGar/projects/ecommerce/testsupport/builders/OrderItemBuilder.java
+++ b/src/test/java/com/waalterGar/projects/ecommerce/testsupport/builders/OrderItemBuilder.java
@@ -1,5 +1,6 @@
 package com.waalterGar.projects.ecommerce.testsupport.builders;
 
+import com.waalterGar.projects.ecommerce.entity.Order;
 import com.waalterGar.projects.ecommerce.entity.OrderItem;
 import com.waalterGar.projects.ecommerce.utils.Currency;
 
@@ -7,12 +8,14 @@ import java.math.BigDecimal;
 
 public class OrderItemBuilder {
     private String sku = "SKU-TEST";
+    private Order order;
     private String name = "Test Item";
     private BigDecimal unitPrice = new BigDecimal("10.00");
     private Currency currency = Currency.EUR;
     private int quantity = 1;
 
     public OrderItemBuilder withSku(String s) { this.sku = s; return this; }
+    public OrderItemBuilder withOrder(Order o) { this.order = o; return this; }
     public OrderItemBuilder withName(String n) { this.name = n; return this; }
     public OrderItemBuilder withUnitPrice(BigDecimal p) { this.unitPrice = p; return this; }
     public OrderItemBuilder withCurrency(Currency c) { this.currency = c; return this; }
@@ -21,6 +24,7 @@ public class OrderItemBuilder {
     public OrderItem build() {
         OrderItem i = new OrderItem();
         i.setProductSku(sku);
+        i.setOrder(order);
         i.setProductName(name);
         i.setUnitPrice(unitPrice);
         i.setCurrency(currency);

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,3 @@
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=false
+spring.datasource.hikari.data-source-properties.sslMode=DISABLED


### PR DESCRIPTION
## Summary
Finalize the Orders persistence layer with integration tests on a real MySQL via Testcontainers, and update the README with how to run tests, validation rules, and global error handling (ProblemDetail).

## What’s included
- JPA ITs for Orders:
  - Distinct roots when fetching collections (no duplicates; correct item counts)
  - Orphan removal on removing items from an Order aggregate
  - Cascade persist: saving Order also persists OrderItems (IDs + back-refs verified)
- Test-support builders adjusted to use domain helpers
- README updates:
  - Added Testcontainers to the stack and clarified that tests don’t require docker-compose
  - Clear run commands for controller slice, repository ITs, and full suite
  - Expanded ProblemDetail catalog (400/404/415/406) and note on UnexpectedTypeException → 400
  - Documented createOrder Bean Validation constraints and 400 error shape
  
  ## Notes
- No production runtime behavior changed, aside from test-support builder improvements used by tests.