### PR TITLE
docs(openapi): Swagger UI + minimal tagging; commons-lang3 pin; README docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,22 @@ Esto levantará:
 ./mvnw spring-boot:run
 ```
 
+_Tras iniciar la app, puedes navegar a **Swagger UI** en `http://localhost:8080/api/swagger-ui/index.html`._
+
 > 🔎 **Tests**: no necesitas `docker-compose` para ejecutar los tests de persistencia; **Testcontainers** arranca un MySQL efímero automáticamente.
+
+---
+
+## 📖 API Docs (OpenAPI / Swagger)
+
+La API expone documentación OpenAPI y una UI interactiva:
+
+- **Swagger UI**: `http://localhost:8080/api/swagger-ui/index.html`
+- **Esquema OpenAPI (JSON)**: `http://localhost:8080/api/v3/api-docs`
+
+Notas:
+- La documentación se genera automáticamente a partir de los **controladores** y **DTOs**.
+- Los **errores** siguen **RFC 7807** (`application/problem+json`) mediante el **handler global**.
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,18 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 
+		<!-- OpenAPI / Swagger -->
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.8.13</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.18.0</version> <!-- or newer -->
+		</dependency>
+
 		<!-- Runtime DB driver -->
 		<dependency>
 			<groupId>com.mysql</groupId>

--- a/src/main/java/com/waalterGar/projects/ecommerce/ApiDocsConfig.java
+++ b/src/main/java/com/waalterGar/projects/ecommerce/ApiDocsConfig.java
@@ -1,0 +1,20 @@
+package com.waalterGar.projects.ecommerce;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ApiDocsConfig {
+
+    @Bean
+    public OpenAPI ecommerceOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Ecommerce API")
+                        .version("v1")
+                        .description("Simple ecommerce backend (Spring Boot 3, JPA, MySQL/Testcontainers). "
+                                + "Includes global ProblemDetail errors and validation on DTOs."));
+    }
+}

--- a/src/main/java/com/waalterGar/projects/ecommerce/controller/OrderController.java
+++ b/src/main/java/com/waalterGar/projects/ecommerce/controller/OrderController.java
@@ -3,18 +3,25 @@ package com.waalterGar.projects.ecommerce.controller;
 import com.waalterGar.projects.ecommerce.Dto.OrderDto;
 import com.waalterGar.projects.ecommerce.Dto.createOrderDto;
 import com.waalterGar.projects.ecommerce.service.OrderService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Orders", description = "Create and retrieve orders")
 @RequiredArgsConstructor
 @RequestMapping("/orders")
 @RestController
 public class OrderController {
     private final OrderService orderService;
 
+    @Operation(summary = "Create a new order")
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public ResponseEntity<OrderDto> createOrder(@Valid @RequestBody createOrderDto orderDto){
@@ -22,6 +29,8 @@ public class OrderController {
         return new ResponseEntity<>(createdOrder, HttpStatus.CREATED);
     }
 
+
+    @Operation(summary = "Get order by externalId")
     @GetMapping("/{orderNumber}")
     public ResponseEntity<OrderDto> getOrderByOrderNumber(@PathVariable String orderNumber){
         OrderDto order = orderService.getOrderByExternalId(orderNumber);

--- a/src/main/java/com/waalterGar/projects/ecommerce/controller/ProductController.java
+++ b/src/main/java/com/waalterGar/projects/ecommerce/controller/ProductController.java
@@ -2,6 +2,11 @@ package com.waalterGar.projects.ecommerce.controller;
 
 import com.waalterGar.projects.ecommerce.Dto.ProductDto;
 import com.waalterGar.projects.ecommerce.service.ProductService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -9,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "Products", description = "Manage products")
 @RequiredArgsConstructor
 @RequestMapping("/products")
 @RestController
@@ -27,6 +33,7 @@ public class ProductController {
         return new ResponseEntity<>(createdProduct, HttpStatus.CREATED);
     }
 
+    @Operation(summary = "Get product by SKU")
     @GetMapping("/{sku}")
     public ResponseEntity<ProductDto> getProductBySku(@PathVariable String sku) {
         ProductDto product = productService.getProductBySku(sku);


### PR DESCRIPTION
## Summary
Add OpenAPI/Swagger documentation and minimal endpoint summaries, keeping controllers concise.

## Changes
- Add dependency: springdoc-openapi-starter-webmvc-ui
- Pin org.apache.commons:commons-lang3 to a safe version (>= 3.18.0)
- Add ApiDocsConfig with OpenAPI metadata (title, version, description)
- Apply minimal annotations in controllers: @Tag (class) and @Operation(summary=...) (methods)
- Update README with Swagger UI and OpenAPI JSON URLs and note about RFC 7807 errors

## How to verify
1) Run the app: `./mvnw spring-boot:run`
2) Swagger UI: `http://localhost:8080/api/swagger-ui/index.html`
3) OpenAPI JSON: `http://localhost:8080/api/v3/api-docs`
4) Confirm endpoints are grouped by tag and display summaries.