### PR TITLE
feat(checkout): cart→order endpoint, post-checkout guards; WebMvc + service tests, docs

### DIFF
--- a/src/main/java/com/waalterGar/projects/ecommerce/Dto/CheckoutRequestDto.java
+++ b/src/main/java/com/waalterGar/projects/ecommerce/Dto/CheckoutRequestDto.java
@@ -1,0 +1,14 @@
+package com.waalterGar.projects.ecommerce.Dto;
+
+
+import lombok.*;
+
+@EqualsAndHashCode
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CheckoutRequestDto {
+    private String customerExternalId;
+    private String note;
+}

--- a/src/main/java/com/waalterGar/projects/ecommerce/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/waalterGar/projects/ecommerce/api/GlobalExceptionHandler.java
@@ -151,6 +151,11 @@ public class GlobalExceptionHandler {
         return pd(HttpStatus.BAD_REQUEST, "Invalid pagination parameters", ex.getMessage(), URI.create("urn:problem:invalid-pagination"), req);
     }
 
+    @ExceptionHandler(IllegalStateException.class)
+    public ProblemDetail handleIllegalState(IllegalStateException ex, HttpServletRequest req) {
+        return pd(HttpStatus.BAD_REQUEST, "Invalid state", ex.getMessage(), TYPE_INVALID, req);
+    }
+
     @ExceptionHandler(InvalidSortException.class)
     public ProblemDetail handleInvalidSort(InvalidSortException ex, HttpServletRequest req) {
         ProblemDetail problem = pd(

--- a/src/main/java/com/waalterGar/projects/ecommerce/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/waalterGar/projects/ecommerce/api/GlobalExceptionHandler.java
@@ -153,7 +153,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(IllegalStateException.class)
     public ProblemDetail handleIllegalState(IllegalStateException ex, HttpServletRequest req) {
-        return pd(HttpStatus.BAD_REQUEST, "Invalid state", ex.getMessage(), TYPE_INVALID, req);
+        return pd(HttpStatus.BAD_REQUEST, "Invalid Request", ex.getMessage(), TYPE_INVALID, req);
     }
 
     @ExceptionHandler(InvalidSortException.class)

--- a/src/main/java/com/waalterGar/projects/ecommerce/controller/CartController.java
+++ b/src/main/java/com/waalterGar/projects/ecommerce/controller/CartController.java
@@ -5,6 +5,7 @@ import com.waalterGar.projects.ecommerce.Dto.CartDto;
 import com.waalterGar.projects.ecommerce.Dto.OrderDto;
 import com.waalterGar.projects.ecommerce.Dto.UpdateCartItemDto;
 import com.waalterGar.projects.ecommerce.service.CartService;
+import com.waalterGar.projects.ecommerce.service.CheckoutService;
 import com.waalterGar.projects.ecommerce.utils.Currency;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.*;
 @AllArgsConstructor
 public class CartController {
     private final CartService cartService;
+    private final CheckoutService checkoutService;
 
     @Operation(summary = "Create a new cart")
     @PostMapping
@@ -53,5 +55,13 @@ public class CartController {
     @DeleteMapping("/{externalId}/items")
     public ResponseEntity<CartDto> clearCart(@PathVariable("externalId") String externalId) {
         return ResponseEntity.ok(cartService.clearCart(externalId));
+    }
+
+    @Operation(summary = "Checkout cart")
+    @PostMapping("/{externalId}/checkout")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ResponseEntity<OrderDto> checkout(@PathVariable("externalId") String externalId, @RequestParam("customerId") String customerId) {
+        OrderDto createdOrder = checkoutService.checkout(externalId, customerId);
+        return new ResponseEntity<>(createdOrder, HttpStatus.CREATED);
     }
 }

--- a/src/main/java/com/waalterGar/projects/ecommerce/service/CheckoutService.java
+++ b/src/main/java/com/waalterGar/projects/ecommerce/service/CheckoutService.java
@@ -1,4 +1,4 @@
-package com.waalterGar.projects.ecommerce.service.Implementation;
+package com.waalterGar.projects.ecommerce.service;
 
 import com.waalterGar.projects.ecommerce.Dto.OrderDto;
 

--- a/src/main/java/com/waalterGar/projects/ecommerce/service/Implementation/CartServiceImpl.java
+++ b/src/main/java/com/waalterGar/projects/ecommerce/service/Implementation/CartServiceImpl.java
@@ -9,6 +9,7 @@ import com.waalterGar.projects.ecommerce.repository.CartRepository;
 import com.waalterGar.projects.ecommerce.repository.ProductRepository;
 import com.waalterGar.projects.ecommerce.service.CartService;
 import com.waalterGar.projects.ecommerce.service.exception.InactiveProductException;
+import com.waalterGar.projects.ecommerce.utils.CartStatus;
 import com.waalterGar.projects.ecommerce.utils.Currency;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -54,6 +55,8 @@ public class CartServiceImpl implements CartService {
 
         Cart cart = cartRepository.findByExternalId(externalId)
                 .orElseThrow(() -> new NoSuchElementException("Cart not found"));
+
+        if (cart.getStatus() != CartStatus.NEW) throw new IllegalStateException("Cart is not editable");
 
         Product product = productRepository.findBySku(sku)
                 .orElseThrow(() -> new NoSuchElementException("Product not found"));
@@ -103,6 +106,8 @@ public class CartServiceImpl implements CartService {
         Cart cart = cartRepository.findByExternalId(externalId)
                 .orElseThrow(() -> new NoSuchElementException("Cart not found"));
 
+        if (cart.getStatus() != CartStatus.NEW) throw new IllegalStateException("Cart is not editable");
+
         CartItem item = cart.getItems().stream()
                 .filter(ci -> sku.equals(ci.getProductSku()))
                 .findFirst().orElseThrow(() -> new NoSuchElementException("Item not found in cart: " + sku));
@@ -137,6 +142,8 @@ public class CartServiceImpl implements CartService {
         Cart cart = cartRepository.findByExternalId(externalId)
                 .orElseThrow(() -> new NoSuchElementException("Cart not found"));
 
+        if (cart.getStatus() != CartStatus.NEW) throw new IllegalStateException("Cart is not editable");
+
         cart.getItems().stream()
                 .filter(ci -> sku.equals(ci.getProductSku()))
                 .findFirst()
@@ -150,6 +157,9 @@ public class CartServiceImpl implements CartService {
     public CartDto clearCart(String externalId) {
         Cart cart = cartRepository.findByExternalId(externalId)
                 .orElseThrow(() -> new NoSuchElementException("Cart not found"));
+
+        if (cart.getStatus() != CartStatus.NEW) throw new IllegalStateException("Cart is not editable");
+
         cart.clearItems();
         Cart saved = cartRepository.save(cart);
         return CartMapper.toDto(saved);

--- a/src/main/java/com/waalterGar/projects/ecommerce/service/Implementation/CheckoutService.java
+++ b/src/main/java/com/waalterGar/projects/ecommerce/service/Implementation/CheckoutService.java
@@ -1,0 +1,7 @@
+package com.waalterGar.projects.ecommerce.service.Implementation;
+
+import com.waalterGar.projects.ecommerce.Dto.OrderDto;
+
+public interface CheckoutService {
+    OrderDto checkout(String cartExternalId, String customerExternalId);
+}

--- a/src/main/java/com/waalterGar/projects/ecommerce/service/Implementation/CheckoutServiceImpl.java
+++ b/src/main/java/com/waalterGar/projects/ecommerce/service/Implementation/CheckoutServiceImpl.java
@@ -1,0 +1,75 @@
+package com.waalterGar.projects.ecommerce.service.Implementation;
+
+import com.waalterGar.projects.ecommerce.Dto.OrderDto;
+import com.waalterGar.projects.ecommerce.Dto.createOrderDto;
+import com.waalterGar.projects.ecommerce.Dto.createOrderItemDto;
+import com.waalterGar.projects.ecommerce.entity.Cart;
+import com.waalterGar.projects.ecommerce.entity.Order;
+import com.waalterGar.projects.ecommerce.repository.CartRepository;
+import com.waalterGar.projects.ecommerce.repository.OrderRepository;
+import com.waalterGar.projects.ecommerce.repository.ProductRepository;
+import com.waalterGar.projects.ecommerce.service.CheckoutService;
+import com.waalterGar.projects.ecommerce.service.OrderService;
+import com.waalterGar.projects.ecommerce.utils.CartStatus;
+import com.waalterGar.projects.ecommerce.utils.Currency;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import jakarta.transaction.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.NoSuchElementException;
+
+@RequiredArgsConstructor
+@Service
+public class CheckoutServiceImpl implements CheckoutService {
+    private final CartRepository cartRepository;
+    private final ProductRepository productRepository;
+    private final OrderRepository orderRepository;
+    private final OrderService orderService;
+
+    @Override
+    @Transactional
+    public OrderDto checkout(String cartExternalId, String customerExternalId) {
+        if (cartExternalId == null || cartExternalId.isBlank()) {
+            throw new IllegalArgumentException("cartExternalId is required");
+        }
+
+        if (customerExternalId == null || customerExternalId.isBlank()) {
+            throw new IllegalArgumentException("customerExternalId is required");
+        }
+
+        Cart cart = cartRepository.findByExternalId(cartExternalId)
+                .orElseThrow(() -> new NoSuchElementException("Cart not found"));
+
+        if (cart.getStatus() != null && cart.getStatus() != CartStatus.NEW) {
+            throw new IllegalStateException("Cart is not editable or already checked out");
+        }
+
+        if (cart.getItems() == null || cart.getItems().isEmpty()) {
+            throw new IllegalArgumentException("Cart is empty");}
+
+        Currency cartCurrency = cart.getCurrency();
+        if (cartCurrency == null) {
+            throw new IllegalArgumentException("Cart currency is not set");
+        }
+
+        createOrderDto dto = new createOrderDto();
+        dto.setCustomerExternalId(customerExternalId);
+        dto.setItems(
+                cart.getItems().stream().map(ci -> {
+                    createOrderItemDto oi = new createOrderItemDto();
+                    oi.setProductSku(ci.getProductSku());
+                    oi.setQuantity(ci.getQuantity());
+                    return oi;
+                }).toList()
+        );
+        OrderDto order = orderService.createOrder(dto);
+
+        // 6) Mark cart as checked out
+        cart.setStatus(CartStatus.CHECKED_OUT);
+        cart.setCheckedOutAt(LocalDateTime.now());
+        cartRepository.save(cart);
+
+        return order;
+    }
+}

--- a/src/test/java/com/waalterGar/projects/ecommerce/controller/CartCheckoutControllerTest.java
+++ b/src/test/java/com/waalterGar/projects/ecommerce/controller/CartCheckoutControllerTest.java
@@ -141,7 +141,7 @@ public class CartCheckoutControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
                 .andExpect(jsonPath("$.type").value("urn:problem:invalid-request"))
-                .andExpect(jsonPath("$.title").value("Invalid state"));
+                .andExpect(jsonPath("$.title").value("Invalid Request"));
 
         verify(checkoutService).checkout(EXTERNAL_ID, CUSTOMER_ID);
         verifyNoMoreInteractions(checkoutService);

--- a/src/test/java/com/waalterGar/projects/ecommerce/controller/CartCheckoutControllerTest.java
+++ b/src/test/java/com/waalterGar/projects/ecommerce/controller/CartCheckoutControllerTest.java
@@ -1,0 +1,157 @@
+package com.waalterGar.projects.ecommerce.controller;
+
+
+import com.waalterGar.projects.ecommerce.Dto.OrderDto;
+import com.waalterGar.projects.ecommerce.api.GlobalExceptionHandler;
+import com.waalterGar.projects.ecommerce.service.CartService;
+import com.waalterGar.projects.ecommerce.service.CheckoutService;
+import com.waalterGar.projects.ecommerce.service.exception.InactiveProductException;
+import com.waalterGar.projects.ecommerce.service.exception.InsufficientStockException;
+import org.junit.jupiter.api.DisplayName;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+import java.net.URI;
+import java.util.NoSuchElementException;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+
+@WebMvcTest(controllers = CartController.class)
+@Import(GlobalExceptionHandler.class)
+@AutoConfigureMockMvc(addFilters = false)
+public class CartCheckoutControllerTest {
+    private static final String BASE_URL = "/carts";
+    private static final String CART_ID = "cart-123";
+    private static final String CUSTOMER_ID = "a1f4e12c-8d5c-4c1b-b3e1-7e2c1d123456";
+    private static final String ORDER_ID = "ord-999";
+    private static final String EXTERNAL_ID = "cart-123";
+
+    @Autowired
+    MockMvc mvc;
+
+    @MockitoBean
+    CartService cartService;
+
+    @MockitoBean CheckoutService checkoutService;
+
+    @Test
+    @DisplayName("POST /carts/{id}/checkout?customerId=... -> 201 Created with Location and body")
+    void checkout_happyPath_returns201_withLocation_andBody() throws Exception {
+        when(checkoutService.checkout(CART_ID, CUSTOMER_ID)).thenReturn(order(ORDER_ID));
+
+        mvc.perform(post(BASE_URL + "/" + CART_ID + "/checkout")
+                        .param("customerId", CUSTOMER_ID)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.externalId").value(ORDER_ID))
+                .andExpect(handler().handlerType(CartController.class))
+                .andExpect(handler().methodName("checkout"));
+
+        verify(checkoutService).checkout(CART_ID, CUSTOMER_ID);
+        verifyNoMoreInteractions(checkoutService);
+    }
+
+    @Test
+    @DisplayName("POST /carts/{externalId}/checkout without customerId -> 400 ProblemDetail")
+    void checkout_missingCustomer_returns400_problem() throws Exception {
+        mvc.perform(post(BASE_URL + "/" + EXTERNAL_ID + "/checkout")
+                        .accept(MediaType.APPLICATION_PROBLEM_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
+                .andExpect(jsonPath("$.type").value("urn:problem:missing-param"))
+                .andExpect(jsonPath("$.title").value("Missing Parameter"));
+
+        verifyNoInteractions(checkoutService);
+    }
+
+    @Test
+    @DisplayName("POST /carts/{externalId}/checkout -> 404 when cart not found")
+    void checkout_cartNotFound_returns404_problem() throws Exception {
+        when(checkoutService.checkout(anyString(), anyString()))
+                .thenThrow(new NoSuchElementException("Cart not found"));
+
+        mvc.perform(post(BASE_URL + "/" + EXTERNAL_ID + "/checkout")
+                        .param("customerId", CUSTOMER_ID)
+                        .accept(MediaType.APPLICATION_PROBLEM_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
+                .andExpect(jsonPath("$.type").value("urn:problem:not-found"))
+                .andExpect(jsonPath("$.title").value("Resource Not Found"));
+
+        verify(checkoutService).checkout(EXTERNAL_ID, CUSTOMER_ID);
+        verifyNoMoreInteractions(checkoutService);
+    }
+
+    @Test
+    @DisplayName("POST /carts/{externalId}/checkout -> 422 when inactive product")
+    void checkout_inactiveProduct_returns422_problem() throws Exception {
+        when(checkoutService.checkout(anyString(), anyString()))
+                .thenThrow(new InactiveProductException("Product is inactive"));
+
+        mvc.perform(post(BASE_URL + "/" + EXTERNAL_ID + "/checkout")
+                        .param("customerId", CUSTOMER_ID)
+                        .accept(MediaType.APPLICATION_PROBLEM_JSON))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
+                .andExpect(jsonPath("$.type").value("urn:problem:inactive-product"))
+                .andExpect(jsonPath("$.title").value("Inactive Product"));
+
+        verify(checkoutService).checkout(EXTERNAL_ID, CUSTOMER_ID);
+        verifyNoMoreInteractions(checkoutService);
+    }
+
+    @Test
+    @DisplayName("POST /carts/{externalId}/checkout returns 422 when insufficient of stock")
+    void checkout_outOfStock_returns409_problem() throws Exception {
+        when(checkoutService.checkout(anyString(), anyString()))
+                .thenThrow(new InsufficientStockException("Insufficient stock"));
+
+        mvc.perform(post(BASE_URL + "/" + EXTERNAL_ID + "/checkout")
+                        .param("customerId", CUSTOMER_ID)
+                        .accept(MediaType.APPLICATION_PROBLEM_JSON))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
+                .andExpect(jsonPath("$.type").value("urn:problem:insufficient-stock"))
+                .andExpect(jsonPath("$.title").value("Insufficient Stock"));
+
+        verify(checkoutService).checkout(EXTERNAL_ID, CUSTOMER_ID);
+        verifyNoMoreInteractions(checkoutService);
+    }
+
+    @Test
+    @DisplayName("POST /carts/{externalId}/checkout -> 400 when invalid state (already checked out)")
+    void checkout_invalidState_returns400_problem() throws Exception {
+        when(checkoutService.checkout(anyString(), anyString()))
+                .thenThrow(new IllegalStateException("Cart is not editable or already checked out"));
+
+        mvc.perform(post(BASE_URL + "/" + EXTERNAL_ID + "/checkout")
+                        .param("customerId", CUSTOMER_ID)
+                        .accept(MediaType.APPLICATION_PROBLEM_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
+                .andExpect(jsonPath("$.type").value("urn:problem:invalid-request"))
+                .andExpect(jsonPath("$.title").value("Invalid state"));
+
+        verify(checkoutService).checkout(EXTERNAL_ID, CUSTOMER_ID);
+        verifyNoMoreInteractions(checkoutService);
+    }
+
+    // Helper method
+    private static OrderDto order(String externalId) {
+        OrderDto dto = new OrderDto();
+        dto.setExternalId(externalId);
+        return dto;
+    }
+
+}

--- a/src/test/java/com/waalterGar/projects/ecommerce/service/Implementation/CheckoutServiceImplTest.java
+++ b/src/test/java/com/waalterGar/projects/ecommerce/service/Implementation/CheckoutServiceImplTest.java
@@ -1,0 +1,219 @@
+package com.waalterGar.projects.ecommerce.service.Implementation;
+
+import com.waalterGar.projects.ecommerce.repository.ProductRepository;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import com.waalterGar.projects.ecommerce.Dto.CheckoutRequestDto;
+import com.waalterGar.projects.ecommerce.Dto.OrderDto;
+import com.waalterGar.projects.ecommerce.Dto.createOrderDto;
+import com.waalterGar.projects.ecommerce.Dto.createOrderItemDto;
+import com.waalterGar.projects.ecommerce.entity.Cart;
+import com.waalterGar.projects.ecommerce.entity.CartItem;
+import com.waalterGar.projects.ecommerce.repository.CartRepository;
+import com.waalterGar.projects.ecommerce.service.OrderService;
+import com.waalterGar.projects.ecommerce.service.exception.InactiveProductException;
+import com.waalterGar.projects.ecommerce.service.exception.InsufficientStockException;
+import com.waalterGar.projects.ecommerce.utils.CartStatus;
+import com.waalterGar.projects.ecommerce.utils.Currency;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class CheckoutServiceImplTest {
+
+    @Mock CartRepository cartRepository;
+    @Mock OrderService orderService;
+
+    @InjectMocks CheckoutServiceImpl checkoutService;
+
+    private static final String CART_ID = "cart-123";
+    private static final String CUSTOMER_ID = "cust-999";
+    private static final String SKU1 = "MUG-LOGO-001";
+    private static final String SKU2 = "TSHIRT-LOGO-001";
+
+    // ---------- Happy path ----------
+
+    @Test
+    @DisplayName("checkout: delegates to OrderService, marks cart CHECKED_OUT, returns OrderDto")
+    void checkout_happyPath_delegates_and_marksCart() {
+        // Given a cart with two items
+        Cart cart = cartWithItems(CART_ID, Currency.EUR,
+                line(SKU1, 2),
+                line(SKU2, 1)
+        );
+        when(cartRepository.findByExternalId(CART_ID)).thenReturn(Optional.of(cart));
+
+        // Capture the createOrderDto sent to OrderService
+        ArgumentCaptor<createOrderDto> dtoCap = ArgumentCaptor.forClass(createOrderDto.class);
+
+        // Simulate OrderService producing an OrderDto
+        OrderDto created = new OrderDto();
+        created.setExternalId("ord-abc");
+        when(orderService.createOrder(dtoCap.capture())).thenReturn(created);
+
+        // Request payload
+        CheckoutRequestDto body = new CheckoutRequestDto();
+        body.setCustomerExternalId(CUSTOMER_ID);
+
+        // When
+        OrderDto out = checkoutService.checkout(CART_ID, CUSTOMER_ID);
+
+        // Then: service delegates with correct items & customer
+        createOrderDto sent = dtoCap.getValue();
+        assertThat(sent.getCustomerExternalId()).isEqualTo(CUSTOMER_ID);
+        assertThat(sent.getItems()).extracting(createOrderItemDto::getProductSku)
+                .containsExactlyInAnyOrder(SKU1, SKU2);
+        assertThat(sent.getItems()).extracting(createOrderItemDto::getQuantity)
+                .containsExactlyInAnyOrder(2, 1);
+
+        // Cart is marked checked out and saved
+        assertThat(cart.getStatus()).isEqualTo(CartStatus.CHECKED_OUT);
+        assertThat(cart.getCheckedOutAt()).isNotNull();
+        verify(cartRepository).save(cart);
+
+        // Response is the order returned by OrderService
+        assertThat(out.getExternalId()).isEqualTo("ord-abc");
+
+        verify(orderService).createOrder(any(createOrderDto.class));
+        verifyNoMoreInteractions(orderService);
+    }
+
+    // ---------- Guards / Errors ----------
+
+    @Test
+    @DisplayName("checkout: cart not found -> NoSuchElementException('Cart not found')")
+    void checkout_cartNotFound_throws404() {
+        when(cartRepository.findByExternalId(CART_ID)).thenReturn(java.util.Optional.empty());
+
+        assertThatThrownBy(() -> checkoutService.checkout(CART_ID, CUSTOMER_ID))
+                .isInstanceOf(NoSuchElementException.class)
+                .hasMessage("Cart not found");
+
+        verifyNoInteractions(orderService);
+        verify(cartRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("checkout: empty cart -> IllegalArgumentException('Cart is empty')")
+    void checkout_emptyCart_throws400() {
+        Cart empty = new Cart();
+        empty.setExternalId(CART_ID);
+        empty.setStatus(CartStatus.NEW);
+        empty.setCurrency(Currency.EUR);
+        when(cartRepository.findByExternalId(CART_ID)).thenReturn(java.util.Optional.of(empty));
+
+        assertThatThrownBy(() -> checkoutService.checkout(CART_ID, CUSTOMER_ID))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Cart is empty");
+
+        verifyNoInteractions(orderService);
+        verify(cartRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("checkout: cart already CHECKED_OUT -> IllegalStateException")
+    void checkout_alreadyCheckedOut_throws() {
+        Cart checked = cartWithItems(CART_ID, Currency.EUR, line(SKU1, 1));
+        checked.setStatus(CartStatus.CHECKED_OUT);
+        when(cartRepository.findByExternalId(CART_ID)).thenReturn(java.util.Optional.of(checked));
+
+        assertThatThrownBy(() -> checkoutService.checkout(CART_ID, CUSTOMER_ID))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("already checked out");
+
+        verifyNoInteractions(orderService);
+        verify(cartRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("checkout: missing customerExternalId -> IllegalArgumentException")
+    void checkout_missingCustomer_throws400() {
+        assertThatThrownBy(() -> checkoutService.checkout(CART_ID, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("customerExternalId is required");
+
+        verifyNoInteractions(orderService);
+        verify(cartRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("checkout: propagates InactiveProductException from OrderService and does not mark cart")
+    void checkout_inactiveProduct_propagates_andNoSave() {
+        Cart cart = cartWithItems(CART_ID, Currency.EUR, line(SKU1, 1));
+        when(cartRepository.findByExternalId(CART_ID)).thenReturn(java.util.Optional.of(cart));
+
+        when(orderService.createOrder(any(createOrderDto.class)))
+                .thenThrow(new InactiveProductException("Product is inactive: " + SKU1));
+
+        assertThatThrownBy(() -> checkoutService.checkout(CART_ID, CUSTOMER_ID))
+                .isInstanceOf(InactiveProductException.class);
+
+        // Cart status must NOT be changed/saved on failure before delegation returns
+        assertThat(cart.getStatus()).isEqualTo(CartStatus.NEW);
+        assertThat(cart.getCheckedOutAt()).isNull();
+        verify(cartRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("checkout: propagates InsufficientStockException from OrderService and does not mark cart")
+    void checkout_outOfStock_propagates_andNoSave() {
+        Cart cart = cartWithItems(CART_ID, Currency.EUR, line(SKU1, 3));
+        when(cartRepository.findByExternalId(CART_ID)).thenReturn(java.util.Optional.of(cart));
+
+        when(orderService.createOrder(any(createOrderDto.class)))
+                .thenThrow(new InsufficientStockException("Insufficient stock"));
+
+        assertThatThrownBy(() -> checkoutService.checkout(CART_ID, CUSTOMER_ID))
+                .isInstanceOf(InsufficientStockException.class);
+
+        assertThat(cart.getStatus()).isEqualTo(CartStatus.NEW);
+        assertThat(cart.getCheckedOutAt()).isNull();
+        verify(cartRepository, never()).save(any());
+    }
+
+    // ---------- Helpers ----------
+
+    private static CheckoutRequestDto req(String customerExternalId) {
+        CheckoutRequestDto r = new CheckoutRequestDto();
+        r.setCustomerExternalId(customerExternalId);
+        return r;
+    }
+
+    private static Cart cartWithItems(String externalId, Currency currency, CartItem... items) {
+        Cart c = new Cart();
+        c.setId(UUID.randomUUID());
+        c.setExternalId(externalId);
+        c.setCurrency(currency);
+        c.setStatus(CartStatus.NEW);
+        c.setCreatedAt(LocalDateTime.now());
+        c.setUpdatedAt(LocalDateTime.now());
+        c.setItems(new java.util.ArrayList<>());
+        for (CartItem it : items) {
+            it.setCart(c);
+            c.getItems().add(it);
+        }
+        return c;
+    }
+
+    private static CartItem line(String sku, int qty) {
+        CartItem ci = new CartItem();
+        ci.setProductSku(sku);
+        ci.setProductName("n/a");
+        ci.setQuantity(qty);
+        // price snapshot is irrelevant here; OrderService re-reads products and sets prices
+        return ci;
+    }
+}


### PR DESCRIPTION
## Summary
Exposes checkout via HTTP and finalizes the cart-order flow. Once a cart is checked out, all cart mutations are blocked. Includes WebMvc and service tests plus small exception-mapping alignment.

## Changes

### Checkout
- `POST /carts/{externalId}/checkout?customerId=...` → **201 Created** with `OrderDto`
- `CheckoutServiceImpl` delegates to `OrderService.createOrder(...)`  
  (stock, activity, currency checks handled centrally)
- Marks cart `CHECKED_OUT` + `checkedOutAt`

### Guards
- Cart mutations (`addItem`, `updateQty`, `removeItem`, `clearCart`) now throw when `status != NEW`
- Global handler maps `IllegalStateException` → **400** `urn:problem:invalid-request` (title aligned)

### Tests
- **WebMvc:** checkout success + problem responses (missing param, not-found, inactive, insufficient stock, invalid state)
- **WebMvc:** post-checkout mutation guards (all **400 invalid-request**)
- **Service:** checkout unit tests (delegation, state transition, error propagation)

### Docs
- README/OpenAPI snippets for checkout endpoint and error cases.